### PR TITLE
feat: make config.get always return a string

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -55,9 +55,9 @@ describe('when using a config', () => {
       })
 
       describe('and the variable does not exist', () => {
-        it('should return undefined', () => {
+        it('should return empty string', () => {
           config = createConfig(configByEnv)
-          expect(config.get('NON_EXISTENT')).toBe(undefined)
+          expect(config.get('NON_EXISTENT')).toBe('')
         })
 
         describe('and passing a default value', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { Env, getEnv } from './env'
 
 export interface IConfig {
-  get: (name: string, defaultValue?: string) => string | undefined
+  get: (name: string, defaultValue?: string) => string
   is(env: Env): boolean
   getEnv(): Env
 }
@@ -17,7 +17,7 @@ export function createConfig(configByEnv: ConfigByEnv): IConfig {
   const env = getEnv()
   const config = configByEnv[env]
   return {
-    get: (name, defaultValue) => {
+    get: (name, defaultValue = '') => {
       if (!config) {
         throw new Error(`Could not find a config for env=${env}`)
       }


### PR DESCRIPTION
To avoid typing hell in ts and better dev exp, always return a string. If variable doesn't exist, return empty string.