### PR TITLE
feat: support gatsby on getDefaultEnv

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -76,6 +76,20 @@ describe('when getting default env', () => {
         )
       })
     })
+    describe('and GATSBY_DCL_DEFAULT_ENV is invalid', () => {
+      it('should throw', () => {
+        expect(() =>
+          getDefaultEnv({ GATSBY_DCL_DEFAULT_ENV: 'invalid' })
+        ).toThrow()
+      })
+    })
+    describe('and GATSBY_DCL_DEFAULT_ENV is valid', () => {
+      it('should return GATSBY_DCL_DEFAULT_ENV as default env', () => {
+        expect(getDefaultEnv({ GATSBY_DCL_DEFAULT_ENV: 'dev' })).toBe(
+          Env.DEVELOPMENT
+        )
+      })
+    })
   })
 
   describe('and both DCL_DEFAULT_ENV and REACT_APP_DCL_DEFAULT_ENV are defined', () => {
@@ -95,6 +109,52 @@ describe('when getting default env', () => {
           getDefaultEnv({
             DCL_DEFAULT_ENV: 'dev',
             REACT_APP_DCL_DEFAULT_ENV: 'prod',
+          })
+        ).toThrow()
+      })
+    })
+  })
+
+  describe('and both DCL_DEFAULT_ENV and GATSBY_DCL_DEFAULT_ENV are defined', () => {
+    describe('and both have the same value', () => {
+      it('should return that value as default env', () => {
+        expect(
+          getDefaultEnv({
+            DCL_DEFAULT_ENV: 'dev',
+            GATSBY_DCL_DEFAULT_ENV: 'dev',
+          })
+        ).toBe(Env.DEVELOPMENT)
+      })
+    })
+    describe('and they have different values', () => {
+      it('should throw', () => {
+        expect(() =>
+          getDefaultEnv({
+            DCL_DEFAULT_ENV: 'dev',
+            GATSBY_DCL_DEFAULT_ENV: 'prod',
+          })
+        ).toThrow()
+      })
+    })
+  })
+
+  describe('and both REACT_APP_DCL_DEFAULT_ENV and GATSBY_DCL_DEFAULT_ENV are defined', () => {
+    describe('and both have the same value', () => {
+      it('should return that value as default env', () => {
+        expect(
+          getDefaultEnv({
+            REACT_APP_DCL_DEFAULT_ENV: 'dev',
+            GATSBY_DCL_DEFAULT_ENV: 'dev',
+          })
+        ).toBe(Env.DEVELOPMENT)
+      })
+    })
+    describe('and they have different values', () => {
+      it('should throw', () => {
+        expect(() =>
+          getDefaultEnv({
+            REACT_APP_DCL_DEFAULT_ENV: 'dev',
+            GATSBY_DCL_DEFAULT_ENV: 'prod',
           })
         ).toThrow()
       })

--- a/src/env.ts
+++ b/src/env.ts
@@ -47,7 +47,7 @@ export function parseEnvVar(envVar: string) {
 export function getDefaultEnv(
   envVars: Record<string, string | undefined> = {}
 ): Env {
-  const { DCL_DEFAULT_ENV, REACT_APP_DCL_DEFAULT_ENV } = envVars
+  const { DCL_DEFAULT_ENV, REACT_APP_DCL_DEFAULT_ENV, GATSBY_DCL_DEFAULT_ENV } = envVars
 
   if (
     DCL_DEFAULT_ENV &&
@@ -59,12 +59,36 @@ export function getDefaultEnv(
     )
   }
 
+  if (
+    DCL_DEFAULT_ENV &&
+    GATSBY_DCL_DEFAULT_ENV &&
+    DCL_DEFAULT_ENV !== GATSBY_DCL_DEFAULT_ENV
+  ) {
+    throw new Error(
+      'You have defined both DCL_DEFAULT_ENV and GATSBY_DCL_DEFAULT_ENV with different values'
+    )
+  }
+
+  if (
+    REACT_APP_DCL_DEFAULT_ENV &&
+    GATSBY_DCL_DEFAULT_ENV &&
+    REACT_APP_DCL_DEFAULT_ENV !== GATSBY_DCL_DEFAULT_ENV
+  ) {
+    throw new Error(
+      'You have defined both REACT_APP_DCL_DEFAULT_ENV and GATSBY_DCL_DEFAULT_ENV with different values'
+    )
+  }
+
   if (DCL_DEFAULT_ENV) {
     return parseEnvVar(DCL_DEFAULT_ENV)
   }
 
   if (REACT_APP_DCL_DEFAULT_ENV) {
     return parseEnvVar(REACT_APP_DCL_DEFAULT_ENV)
+  }
+
+  if (GATSBY_DCL_DEFAULT_ENV) {
+    return parseEnvVar(GATSBY_DCL_DEFAULT_ENV)
   }
 
   return Env.PRODUCTION


### PR DESCRIPTION
support `GATSBY_DCL_DEFAULT_ENV` as default env variable

![image](https://user-images.githubusercontent.com/208789/195639755-84040c3e-3371-4cdc-9cc3-700592304ff1.png)

https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/