### PR TITLE
feat: Use custom system environment variables map

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -120,7 +120,7 @@ describe('when using a config', () => {
       }
     })
 
-    describe('and the default environment is defined in a custom environment map', () => {
+    describe('and the default environment is defined in a custom environment variables map', () => {
       let customEnvironment: EnvironmentVariables
 
       beforeEach(() => {

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -36,7 +36,7 @@ describe('when using a config', () => {
           })
 
           describe('and the variable exists', () => {
-            it('should return the value for that variable for the Env.DEVELOPMENT config', () => {
+            it(`should return the value for that variable for the ${environment} config`, () => {
               expect(createConfig(configByEnv).get('FOO')).toBe(
                 `bar-${environment}`
               )

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -120,7 +120,7 @@ describe('when using a config', () => {
       }
     })
 
-    describe('and the env is defined in a custom system environment map', () => {
+    describe('and the default environment is defined in a custom environment map', () => {
       let customEnvironment: EnvironmentVariables
 
       beforeEach(() => {
@@ -137,7 +137,7 @@ describe('when using a config', () => {
       })
     })
 
-    describe('and the env is defined in a system environment variable', () => {
+    describe('and the default environment is defined in the process environment variable', () => {
       beforeEach(() => {
         process.env.DCL_DEFAULT_ENV = Env.STAGING
       })

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -137,7 +137,7 @@ describe('when using a config', () => {
       })
     })
 
-    describe('and the default environment is defined in the process environment variable', () => {
+    describe('and the default environment is defined in the process.env variable', () => {
       beforeEach(() => {
         process.env.DCL_DEFAULT_ENV = Env.STAGING
       })

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Env, getEnv } from './env'
+import { Env, EnvironmentVariables, getEnv } from './env'
 
 export interface IConfig {
   get: (name: string, defaultValue?: string) => string
@@ -13,8 +13,8 @@ export type ConfigByEnv = Partial<Record<Env, Record<string, string>>>
  * @param configByEnv - A record of variables for each Env
  * @returns Config
  */
-export function createConfig(configByEnv: ConfigByEnv): IConfig {
-  const env = getEnv()
+export function createConfig(configByEnv: ConfigByEnv, options?: { systemEnvVariables?: EnvironmentVariables }): IConfig {
+  const env = getEnv(options?.systemEnvVariables)
   const config = configByEnv[env]
   return {
     get: (name, defaultValue = '') => {

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -203,14 +203,20 @@ describe('when getting env', () => {
       })
     })
 
-    describe('and env is "dev"', () => {
+    describe('and the system env variable is "dev"', () => {
       it('should return Env.DEVELOPMENT', () => {
         mockProcess({ DCL_DEFAULT_ENV: 'dev' })
         expect(getEnv()).toBe(Env.DEVELOPMENT)
       })
     })
 
-    describe('and search param is "stg" and env is "dev"', () => {
+    describe("and there's a custom system environment variable set to dev", () => {
+      it('should return Env.DEVELOPMENT', () => {
+        expect(getEnv({ DCL_DEFAULT_ENV: 'dev' })).toBe(Env.DEVELOPMENT)
+      })
+    })
+
+    describe('and search param is "stg" and the system env variable is "dev"', () => {
       it('should return Env.STAGING', () => {
         mockLocation({ search: '?env=stg' })
         mockProcess({ DCL_DEFAULT_ENV: 'dev' })

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,6 +6,8 @@ export enum Env {
   PRODUCTION = 'prod',
 }
 
+export type EnvironmentVariables = Record<string, string | undefined>
+
 /**
  * Returns an array with all the possible envs
  */
@@ -98,7 +100,7 @@ export function getDefaultEnv(
  * Returns the Env to be used
  * @returns Env
  */
-export function getEnv(): Env {
+export function getEnv(systemEnvVariables: EnvironmentVariables = process.env): Env {
   if (typeof window !== 'undefined') {
     const envFromQueryParam = getEnvFromQueryParam(window.location)
     if (envFromQueryParam) {
@@ -111,5 +113,5 @@ export function getEnv(): Env {
     }
   }
 
-  return getDefaultEnv(process.env)
+  return getDefaultEnv(systemEnvVariables)
 }


### PR DESCRIPTION
This PR adds the capability of using a custom system environment variables map instead of defaulting to the `process.env` one. This is useful for other build systems like vite which don't use `process.env` but use another global variable to store the environment variables.