### PR TITLE
feat: add support for VITE_DCL_DEFAULT_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For example:
 
 If no TLD is found and there is no query param, the default environment will be used, which is `Env.PRODUCTION`.
 
-If you want to override the default environment you can use the environment var `DCL_DEFAULT_ENV` or `REACT_APP_DCL_DEFAULT_ENV` and set it with the values `dev`, `stg` or `prod`.
+If you want to override the default environment you can use the environment var `DCL_DEFAULT_ENV`, `REACT_APP_DCL_DEFAULT_ENV` or `VITE_DCL_DEFAULT_ENV` and set it with the values `dev`, `stg` or `prod`.
 
 This can be useful to configure the local environment or for deployments to other non-decentraland domains such as Vercel's.
 

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -91,6 +91,36 @@ describe('when getting default env', () => {
       })
     })
   })
+  describe('and VITE_DCL_DEFAULT_ENV is defined', () => {
+    describe('and VITE_DCL_DEFAULT_ENV is invalid', () => {
+      it('should throw', () => {
+        expect(() =>
+          getDefaultEnv({ VITE_DCL_DEFAULT_ENV: 'invalid' })
+        ).toThrow()
+      })
+    })
+    describe('and VITE_DCL_DEFAULT_ENV is valid', () => {
+      it('should return VITE_DCL_DEFAULT_ENV as default env', () => {
+        expect(getDefaultEnv({ VITE_DCL_DEFAULT_ENV: 'dev' })).toBe(
+          Env.DEVELOPMENT
+        )
+      })
+    })
+    describe('and GATSBY_DCL_DEFAULT_ENV is invalid', () => {
+      it('should throw', () => {
+        expect(() =>
+          getDefaultEnv({ GATSBY_DCL_DEFAULT_ENV: 'invalid' })
+        ).toThrow()
+      })
+    })
+    describe('and GATSBY_DCL_DEFAULT_ENV is valid', () => {
+      it('should return GATSBY_DCL_DEFAULT_ENV as default env', () => {
+        expect(getDefaultEnv({ GATSBY_DCL_DEFAULT_ENV: 'dev' })).toBe(
+          Env.DEVELOPMENT
+        )
+      })
+    })
+  })
 
   describe('and both DCL_DEFAULT_ENV and REACT_APP_DCL_DEFAULT_ENV are defined', () => {
     describe('and both have the same value', () => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -49,7 +49,12 @@ export function parseEnvVar(envVar: string) {
 export function getDefaultEnv(
   envVars: Record<string, string | undefined> = {}
 ): Env {
-  const { DCL_DEFAULT_ENV, REACT_APP_DCL_DEFAULT_ENV, GATSBY_DCL_DEFAULT_ENV } = envVars
+  const {
+    DCL_DEFAULT_ENV,
+    REACT_APP_DCL_DEFAULT_ENV,
+    VITE_DCL_DEFAULT_ENV,
+    GATSBY_DCL_DEFAULT_ENV,
+  } = envVars
 
   if (
     DCL_DEFAULT_ENV &&
@@ -58,6 +63,15 @@ export function getDefaultEnv(
   ) {
     throw new Error(
       'You have defined both DCL_DEFAULT_ENV and REACT_APP_DCL_DEFAULT_ENV with different values'
+    )
+  }
+  if (
+    DCL_DEFAULT_ENV &&
+    VITE_DCL_DEFAULT_ENV &&
+    DCL_DEFAULT_ENV !== VITE_DCL_DEFAULT_ENV
+  ) {
+    throw new Error(
+      'You have defined both DCL_DEFAULT_ENV and VITE_DCL_DEFAULT_ENV with different values'
     )
   }
 
@@ -89,6 +103,10 @@ export function getDefaultEnv(
     return parseEnvVar(REACT_APP_DCL_DEFAULT_ENV)
   }
 
+  if (VITE_DCL_DEFAULT_ENV) {
+    return parseEnvVar(VITE_DCL_DEFAULT_ENV)
+  }
+
   if (GATSBY_DCL_DEFAULT_ENV) {
     return parseEnvVar(GATSBY_DCL_DEFAULT_ENV)
   }
@@ -100,7 +118,9 @@ export function getDefaultEnv(
  * Returns the Env to be used
  * @returns Env
  */
-export function getEnv(systemEnvVariables: EnvironmentVariables = process.env): Env {
+export function getEnv(
+  systemEnvVariables: EnvironmentVariables = process.env
+): Env {
   if (typeof window !== 'undefined') {
     const envFromQueryParam = getEnvFromQueryParam(window.location)
     if (envFromQueryParam) {


### PR DESCRIPTION
This PR adds support for defining the env with `VITE_DCL_DEFAULT_ENV` now that many dapps are using `Vite`