### PR TITLE
fix: support undefined process

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -168,6 +168,29 @@ describe('when getting default env', () => {
     })
   })
 
+  describe('and both DCL_DEFAULT_ENV and VITE_DCL_DEFAULT_ENV are defined', () => {
+    describe('and both have the same value', () => {
+      it('should return that value as default env', () => {
+        expect(
+          getDefaultEnv({
+            DCL_DEFAULT_ENV: 'dev',
+            VITE_DCL_DEFAULT_ENV: 'dev',
+          })
+        ).toBe(Env.DEVELOPMENT)
+      })
+    })
+    describe('and they have different values', () => {
+      it('should throw', () => {
+        expect(() =>
+          getDefaultEnv({
+            DCL_DEFAULT_ENV: 'dev',
+            VITE_DCL_DEFAULT_ENV: 'prod',
+          })
+        ).toThrow()
+      })
+    })
+  })
+
   describe('and both REACT_APP_DCL_DEFAULT_ENV and GATSBY_DCL_DEFAULT_ENV are defined', () => {
     describe('and both have the same value', () => {
       it('should return that value as default env', () => {

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -194,7 +194,8 @@ describe('when getting default env', () => {
 
 describe('when getting env', () => {
   let windowSpy: jest.SpyInstance<Window & typeof globalThis, []>
-  const { env } = process
+  const prevProcess = process
+  const { env: prevEnv } = process
 
   beforeEach(() => {
     windowSpy = jest.spyOn(window, 'window', 'get')
@@ -202,7 +203,8 @@ describe('when getting env', () => {
 
   afterEach(() => {
     windowSpy.mockRestore()
-    process.env = env
+    process = prevProcess
+    process.env = prevEnv
   })
 
   function mockLocation(mock: Partial<Location>) {
@@ -215,7 +217,7 @@ describe('when getting env', () => {
     )
   }
 
-  function mockProcess(mock: Record<string, string | undefined>) {
+  function mockProcessEnv(mock: Record<string, string | undefined>) {
     const prev = { ...process.env }
     process.env = { ...prev, ...mock }
   }
@@ -235,7 +237,7 @@ describe('when getting env', () => {
 
     describe('and the system env variable is "dev"', () => {
       it('should return Env.DEVELOPMENT', () => {
-        mockProcess({ DCL_DEFAULT_ENV: 'dev' })
+        mockProcessEnv({ DCL_DEFAULT_ENV: 'dev' })
         expect(getEnv()).toBe(Env.DEVELOPMENT)
       })
     })
@@ -249,8 +251,15 @@ describe('when getting env', () => {
     describe('and search param is "stg" and the system env variable is "dev"', () => {
       it('should return Env.STAGING', () => {
         mockLocation({ search: '?env=stg' })
-        mockProcess({ DCL_DEFAULT_ENV: 'dev' })
+        mockProcessEnv({ DCL_DEFAULT_ENV: 'dev' })
         expect(getEnv()).toBe(Env.STAGING)
+      })
+    })
+
+    describe('and process is not defined', () => {
+      it('should return Env.PRODUCTION', () => {
+        process = undefined as any
+        expect(getEnv()).toBe(Env.PRODUCTION)
       })
     })
   })
@@ -269,7 +278,7 @@ describe('when getting env', () => {
     })
   })
 
-  describe('and host is "market.decentraland.org"', () => {
+  describe('and host is "builder.decentraland.org"', () => {
     it('should return Env.PRODUCTION', () => {
       mockLocation({ host: 'builder.decentraland.org' })
       expect(getEnv()).toBe(Env.PRODUCTION)

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -257,9 +257,17 @@ describe('when getting env', () => {
     })
 
     describe('and process is not defined', () => {
-      it('should return Env.PRODUCTION', () => {
-        process = undefined as any
-        expect(getEnv()).toBe(Env.PRODUCTION)
+      describe('and no system env variable is defined', () => {
+        it('should return Env.PRODUCTION', () => {
+          process = undefined as any
+          expect(getEnv()).toBe(Env.PRODUCTION)
+        })
+      })
+      describe('and a system env variable is defined', () => {
+        it('should return the system env variable as Env', () => {
+          process = undefined as any
+          expect(getEnv({ DCL_DEFAULT_ENV: 'dev' })).toBe(Env.DEVELOPMENT)
+        })
       })
     })
   })

--- a/src/env.ts
+++ b/src/env.ts
@@ -118,9 +118,7 @@ export function getDefaultEnv(
  * Returns the Env to be used
  * @returns Env
  */
-export function getEnv(
-  systemEnvVariables: EnvironmentVariables = process.env
-): Env {
+export function getEnv(systemEnvVariables?: EnvironmentVariables): Env {
   if (typeof window !== 'undefined') {
     const envFromQueryParam = getEnvFromQueryParam(window.location)
     if (envFromQueryParam) {
@@ -133,5 +131,12 @@ export function getEnv(
     }
   }
 
-  return getDefaultEnv(systemEnvVariables)
+  const envVars =
+    typeof systemEnvVariables === 'undefined' &&
+    typeof process === 'object' &&
+    typeof process.env === 'object'
+      ? process.env
+      : systemEnvVariables
+
+  return getDefaultEnv(envVars)
 }


### PR DESCRIPTION
There are builds where `process` is not defined and is making the library to throw on runtime with the following error: 

```
TypeError: Cannot read properties of undefined (reading 'env')

      120 |  */
      121 | export function getEnv(
    > 122 |   systemEnvVariables: EnvironmentVariables = process.env
```

This PR adds a test that reproduces the issue, and then applies a fix for it.